### PR TITLE
Add fixed-size placeholders for missing product images

### DIFF
--- a/app/product/components/images/ProductPage.module.css
+++ b/app/product/components/images/ProductPage.module.css
@@ -13,6 +13,18 @@
     height: 450px;
     width: 100%;
   }
+
+
+  .mainImagePlaceholder {
+    height: 450px;
+    width: 100%;
+    background: #f1f1f1;
+    color: #7a7a7a;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+  }
   
   /* Carousel container */
   .carouselContainer {
@@ -36,7 +48,8 @@
   }
 
   @media screen and (max-width: 768px) {
-    .mainImage {
+    .mainImage,
+    .mainImagePlaceholder {
       height: 240px;
     }
 
@@ -51,3 +64,14 @@
   @media screen and (max-width: 480px) {
 
   }
+.thumbnailPlaceholder {
+  width: 80px;
+  height: 80px;
+  background: #f1f1f1;
+  color: #7a7a7a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+}

--- a/app/product/components/images/images.tsx
+++ b/app/product/components/images/images.tsx
@@ -9,27 +9,32 @@ interface ProductImagesProps {
 }
 
 const ProductImages: React.FC<ProductImagesProps> = ({ product, selectedColor }) => {
+  const validImages = useMemo(() => {
+    if (!product?.images || product.images.length === 0) return [];
+    return product.images.filter((image) => Boolean(image.image_url));
+  }, [product?.images]);
+
   // Filter images based on selected color
   // Show images where color matches selectedColor OR color is null (general images)
   const filteredImages = useMemo(() => {
-    if (!product?.images || product.images.length === 0) return [];
+    if (validImages.length === 0) return [];
 
     // If no color is selected, show all images
     if (!selectedColor) {
-      return product.images;
+      return validImages;
     }
 
     // Filter images: show color-specific images + general images (color is null)
-    const colorFiltered = product.images.filter(
+    const colorFiltered = validImages.filter(
       img => img.color === selectedColor || img.color === null || img.color === undefined
     );
 
     // If no images match, fall back to all images
-    return colorFiltered.length > 0 ? colorFiltered : product.images;
-  }, [product?.images, selectedColor]);
+    return colorFiltered.length > 0 ? colorFiltered : validImages;
+  }, [validImages, selectedColor]);
 
-  // Use optional chaining to safely initialize the state.
   const [selectedImage, setSelectedImage] = useState(filteredImages[0]);
+  const [isMainImageError, setIsMainImageError] = useState(false);
 
   // Sync selectedImage when filtered images change (e.g., when color changes)
   useEffect(() => {
@@ -40,9 +45,12 @@ const ProductImages: React.FC<ProductImagesProps> = ({ product, selectedColor })
     }
   }, [filteredImages]);
 
-  // Early return if product or its images are missing.
-  if (!product || !product.images || product.images.length === 0) {
-    return <div>Зображення не доступні</div>;
+  useEffect(() => {
+    setIsMainImageError(false);
+  }, [selectedImage?.id]);
+
+  if (!product) {
+    return null;
   }
 
   // Handle thumbnail click
@@ -54,40 +62,47 @@ const ProductImages: React.FC<ProductImagesProps> = ({ product, selectedColor })
     <div className={styles.imageSection}>
       {/* Main (selected) image */}
       <div className={styles.mainImageContainer}>
-        {selectedImage && (
+        {selectedImage && !isMainImageError ? (
           <Image
             key={selectedImage.id}
             src={selectedImage.image_url}
             alt={selectedImage.alt || product.name}
-            width={500} 
-            height={500} 
+            width={500}
+            height={500}
             sizes="(max-width: 768px) 100vw, 500px"
             className={styles.mainImage}
+            onError={() => setIsMainImageError(true)}
           />
+        ) : (
+          <div className={styles.mainImagePlaceholder}>Немає фото</div>
         )}
       </div>
 
       {/* Carousel (thumbnails) - shows filtered images based on selected color */}
       <div className={styles.carouselContainer}>
-        {filteredImages.map((image) => (
-          <div
-            key={image.id}
-            className={
-              selectedImage && image.id === selectedImage.id
-                ? styles.thumbnailSelected
-                : styles.thumbnail
-            }
-            onClick={() => handleThumbnailClick(image)}
-          >
-            <Image
-              src={image.image_url}
-              alt={image.alt || product.name}
-              width={80}
-              height={80}
-              sizes="(max-width: 768px) 100vw, 80px"
-            />
-          </div>
-        ))}
+        {filteredImages.length > 0 ? (
+          filteredImages.map((image) => (
+            <div
+              key={image.id}
+              className={
+                selectedImage && image.id === selectedImage.id
+                  ? styles.thumbnailSelected
+                  : styles.thumbnail
+              }
+              onClick={() => handleThumbnailClick(image)}
+            >
+              <Image
+                src={image.image_url}
+                alt={image.alt || product.name}
+                width={80}
+                height={80}
+                sizes="(max-width: 768px) 100vw, 80px"
+              />
+            </div>
+          ))
+        ) : (
+          <div className={styles.thumbnailPlaceholder}>Немає фото</div>
+        )}
       </div>
     </div>
   );

--- a/app/shared/components/productCard/productCard.module.css
+++ b/app/shared/components/productCard/productCard.module.css
@@ -25,6 +25,19 @@
     object-fit: cover;
   }
 
+  .productImagePlaceholder {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border-radius: 8px;
+    background: #f1f1f1;
+    color: #7a7a7a;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
   .imageWrapper {
     position: relative;
     width: 100%;

--- a/app/shared/components/productCard/productCard.tsx
+++ b/app/shared/components/productCard/productCard.tsx
@@ -16,6 +16,7 @@ interface ProductCardProps {
 const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
   const { isLoading, addToCart } = useCart();
   const { toggleFavorite, isFavorite } = useFavorites();
+  const [isImageError, setIsImageError] = React.useState(false);
 
   const handleAddToCart = (e: React.MouseEvent<HTMLButtonElement>) => {
     // Prevent triggering the parent link navigation
@@ -49,6 +50,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
   };
 
   const firstImage = product.images.length > 0 ? product.images[0] : null;
+  const showImagePlaceholder = !firstImage || isImageError;
   const isFavorited = isFavorite(product.id);
   const isOutOfStock = product.stock < 1;
 
@@ -57,7 +59,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
       <Link href={`/product/${encodeURIComponent(product.slug)}`} prefetch={false}>
         <div>
           <div className={styles.imageWrapper}>
-            {firstImage && (
+            {!showImagePlaceholder && firstImage && (
               <Image
                 src={firstImage.image_url}
                 alt={product.name}
@@ -65,9 +67,16 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
                 width={260}
                 height={260}
                 loading="lazy"
+                onError={() => setIsImageError(true)}
                 placeholder="blur"
                 blurDataURL="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjYwIiBoZWlnaHQ9IjI2MCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZjBmMGYwIi8+PC9zdmc+"
               />
+            )}
+
+            {showImagePlaceholder && (
+              <div className={styles.productImagePlaceholder} aria-label="Зображення недоступне">
+                Немає фото
+              </div>
             )}
 
             {/* Favorite heart icon button */}


### PR DESCRIPTION
### Motivation
- Prevent layout collapse when product images are missing or fail to load by ensuring product cards and the product gallery always reserve the same image space.
- Improve UX consistency across product grids, carousels and product detail pages by providing clear, fixed-size visual fallbacks.

### Description
- Added runtime image-fallback handling to the shared product card by tracking image load errors and rendering a placeholder element when the primary image is absent or fails (`app/shared/components/productCard/productCard.tsx`).
- Added a `.productImagePlaceholder` style to keep the product card image area identical in size and aspect ratio to normal images (`app/shared/components/productCard/productCard.module.css`).
- Hardened the product detail gallery to ignore entries with empty `image_url`, to show a full-size main-image placeholder on missing/broken images, and to render thumbnail placeholders when no thumbnails exist (`app/product/components/images/images.tsx` and `app/product/components/images/ProductPage.module.css`).

### Testing
- Ran `npm run lint` which failed in this environment due to project Next.js/ESLint configuration issues (not introduced by these changes).
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript errors in test files unrelated to the image placeholder changes.
- Started the dev server and executed an automated Playwright script to load the homepage and capture a screenshot to visually validate placeholders (server started successfully and screenshot was produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e00bf0e08324a417739c7ef4cbf0)